### PR TITLE
상, 하 이동 시 타일이 2개씩 생성되는 문제 수정

### DIFF
--- a/backend/src/main/java/dev/gunlog/model/Player.java
+++ b/backend/src/main/java/dev/gunlog/model/Player.java
@@ -60,13 +60,11 @@ public class Player implements Serializable {
         rotateClockwise();
         rightMove();
         rotateCounterClockwise();
-        randomNum();
     }
     public void bottomMove() {
         rotateClockwise();
         leftMove();
         rotateCounterClockwise();
-        randomNum();
     }
 
     private void combine() {


### PR DESCRIPTION
상, 하 이동 시 중복 소스를 제거하려고 좌, 우 이동 메소드를 사용했는데 그 메소드에 타일 생성 메소드가 있어서 생긴 문제